### PR TITLE
Prevent bots from taunting themselves

### DIFF
--- a/bot_client.cpp
+++ b/bot_client.cpp
@@ -399,12 +399,13 @@ void BotClient_Valve_DeathMsg(void *p, int bot_index)
                bots[index].b_spray_logo = TRUE;  // this bot should spray logo now
                bots[index].f_spray_logo_time = gpGlobals->time;
             }
+
+            if (victim_edict != NULL)
+            {
+               BotChatTaunt(bots[index], victim_edict);
+            }
          }
 
-         if (victim_edict != NULL)
-         {
-            BotChatTaunt(bots[index], victim_edict);
-         }
       }
 
       // get the bot index of the victim...


### PR DESCRIPTION
Under some circumstances, the code may call `BotChatTaunt` when a bot kills itself. When the bots are killed by worldspawn the chat event is not triggered, but it can be called for some other frag causes. For example, there is a map where a mortar strikes from time to time in an open area; when bots are killed this way (the message `[bot name] killed self by mortar` is shown) they may say taunt messages, and `%n` gets replaced by their own nickname. I recall observing this in maps with no mortar strikes (maybe `trigger_hurt`, `env_explosion` or `train` killed the bots).

A few lines above the one which calls `BotChatTaunt` there is an `if` statement that checks whether the victim and the killer are the same, but the call is placed after that code block. I just moved the line and another `if` statement which has the line as its body inside the body of the first statement.

I compiled the dll from this repository code (in Windows, using MinGW; a few changes in two makefiles were necessary) and after some testing under extreme conditions that force the bots to be killed by mortar strikes the self-taunting messages do not appear when applying the patch in this pull request, but they do when the current code is used.

Notice this bug probably existed back in HPB_bot.